### PR TITLE
Add Silas Santini and David Wagner as Maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,5 @@ about:
 extra:
   recipe-maintainers:
     - yuvipanda
+    - pancakereport
+    - davidwagner


### PR DESCRIPTION
Silas Santini and David Wagner (@davidwagner) are currently responsible for merging most changes to the `datascience` package and should have the ability to easily distribute the package via conda forge.

I think after this is merged, we may need to file an issue with the following phrase https://conda-forge.org/docs/maintainer/infrastructure/#conda-forge-admin-please-update-team 

Hopefully this is the correct workflow, but it seems like https://conda-forge.org/docs/maintainer/infrastructure/#conda-forge-admin-please-update-team is also possible
